### PR TITLE
Watch only public files when running local server

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ci": "yarn run all-ci-checks",
     "compile-ts": "babel ./src --out-dir ./lib --extensions .ts --ignore '**/__tests__/*' --ignore '**/*.d.ts'",
     "cq": "yarn run all-cq-checks",
-    "dev": "live-server --port=4000 .",
+    "dev": "live-server --port=4000 --watch='index.html,public/**' .",
     "lint": "eslint --cache '**/*.{js,ts}'",
     "publish:default": "echo 'No publication step. Skipping.'",
     "tc": "yarn run typecheck",


### PR DESCRIPTION
This change cuts down on the number of page refreshes when running locally.